### PR TITLE
Added an empty virtual destructor to NodeTraverser

### DIFF
--- a/include/gdproto/profiling/PerfProfiler.h
+++ b/include/gdproto/profiling/PerfProfiler.h
@@ -56,6 +56,8 @@ namespace gdproto
 
             // called when moving the traversal up a level
             virtual void up() {};
+            
+            virtual ~NodeTraverser() {};
         };
 
         // DFS traversal of all nodes


### PR DESCRIPTION
in order to remove a clang compilation warning.
